### PR TITLE
Add extraargs --secure and method to determine python3 location and link

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
+.github
 README.md

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,7 +4,9 @@ name: Master
 on:
   # run on any pushes to master branch
   push:
-    branches: master
+    branches:
+      - master
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,9 @@ name: Pull Requests
 # Build and run tests on all pull requests
 on:
   pull_request:
-    branches: main
+    branches:
+      - master
+      - main
 
 jobs:
   docker:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM linuxserver/smokeping:latest as release
+FROM linuxserver/smokeping:latest AS release
 
 # Copy in default speedtest probe/target config
 COPY conf / /speedtest-conf/
 
 # Install speedtest-cli and it's dependencies
 RUN apk add python3 --no-cache \
-    && (cd /usr/bin && ln -s python3.8 python) \
+    && PYTHON_LNK=$(which python3) \
+    && PYTHON_DIR=$(dirname ${PYTHON_LNK}) \
+    && PYTHON_BIN=$(readlink ${PYTHON_LNK}) \
+    && (cd ${PYTHON_DIR} && ln -s ${PYTHON_BIN} python) \
     && curl -L -s -S -o /usr/share/perl5/vendor_perl/Smokeping/probes/speedtest.pm https://github.com/mad-ady/smokeping-speedtest/raw/master/speedtest.pm \
     && curl -L -s -S -o /usr/local/bin/speedtest-cli https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py \
     && chmod a+x /usr/local/bin/speedtest-cli \
@@ -13,7 +16,7 @@ RUN apk add python3 --no-cache \
     && cat /speedtest-conf/Targets >> /defaults/smoke-conf/Targets
 
 # Build image with tests
-FROM alpine:latest as test
+FROM alpine:latest AS test
 COPY --from=release / /
 COPY test/ /test
 WORKDIR /test

--- a/conf/Probes
+++ b/conf/Probes
@@ -1,3 +1,4 @@
+
 + speedtest
 binary = /usr/local/bin/speedtest-cli
 timeout = 300
@@ -5,6 +6,7 @@ forks = 1
 step = 3600
 offset = random
 pings = 3
+extraargs = --secure
 
 ++ speedtest-download
 measurement = download


### PR DESCRIPTION
- Added `extraargs: --secure` to the speedtest Probe, as it seems to be required now.
- Added a method to automatically determine the `python3` location and link for the symbolic link creation. This should automatically pickup the version, should it change in the base image from linuxserver.io.
- Added .github to .dockerignore

Thought this might be helpful, but won't be offended if you don't agree. 😄 