### PR TITLE
fix: removed python symlink creation as it now already exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ COPY conf / /speedtest-conf/
 
 # Install speedtest-cli and it's dependencies
 RUN apk add python3 --no-cache \
-    && PYTHON_LNK=$(which python3) \
-    && PYTHON_DIR=$(dirname ${PYTHON_LNK}) \
-    && PYTHON_BIN=$(readlink ${PYTHON_LNK}) \
-    && (cd ${PYTHON_DIR} && ln -s ${PYTHON_BIN} python) \
     && curl -L -s -S -o /usr/share/perl5/vendor_perl/Smokeping/probes/speedtest.pm https://github.com/mad-ady/smokeping-speedtest/raw/master/speedtest.pm \
     && curl -L -s -S -o /usr/local/bin/speedtest-cli https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py \
     && chmod a+x /usr/local/bin/speedtest-cli \


### PR DESCRIPTION
Looks like the symlink is now being created during python3 install.