### PR TITLE
feat: ssh probe fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY conf / /speedtest-conf/
 
 # Install speedtest-cli and it's dependencies
 RUN apk add python3 --no-cache \
+    && curl -L -s -S -o /usr/share/perl5/vendor_perl/Smokeping/probes/SSH.pm https://github.com/oetiker/SmokePing/raw/master/lib/Smokeping/probes/SSH.pm \
+    && sed -i 's/127.0.0.1/$ENV{SSH_PROBE_INIT_TARGET}/g' /usr/share/perl5/vendor_perl/Smokeping/probes/SSH.pm \
     && curl -L -s -S -o /usr/share/perl5/vendor_perl/Smokeping/probes/speedtest.pm https://github.com/mad-ady/smokeping-speedtest/raw/master/speedtest.pm \
     && curl -L -s -S -o /usr/local/bin/speedtest-cli https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py \
     && chmod a+x /usr/local/bin/speedtest-cli \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ The default speedtest configuration will poll downloads/uploads every hour to yo
 Results are displayed under the 'Speed Tests' menu in Smokeping.
 This can be modified by via the Probes and Targets config files as per the instructions at https://github.com/mad-ady/smokeping-speedtest.
 
+## ssh probe
+
+This image also contains a working version of the [SSH Probe](https://oss.oetiker.ch/smokeping/probe/SSH.en.html), which is [currently broken](https://github.com/linuxserver/docker-smokeping/issues/142) in the underlying linuxserver image.
+
+If you add an SSH probe to your configuration, you must also set the `SSH_PROBE_INIT_TARGET` environment variable to a valid host running SSH. During initialisation, the probe will ask the target for its public key and verify it can parse the output.
+
+eg.
+```bash
+docker run \
+  -d \
+  --name=smokeping-speedtest \
+  -e SSH_PROBE_INIT_TARGET=my.host \
+  -e PUID=1000 \
+  -e PGID=1000 \
+  -e TZ=Europe/London \
+  -p 80:80 \
+  -v /path/to/smokeping/config:/config \
+  -v /path/to/smokeping/data:/data \
+  --restart unless-stopped \
+  jwigley/smokeping-speedtest
+```
+
 ## credits
 
 This docker image just pieces the bits together. The real work is all done by:

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -24,6 +24,10 @@ check_result ${?} "speedtest-cli can list servers"
 OUTPUT=$(speedtest-cli)
 check_result ${?} "speedtest-cli can execute speed test"
 
+# test 3 - SSH probe compiled successfully
+OUPUT=$(perl -c /usr/share/perl5/vendor_perl/Smokeping/probes/SSH.pm > /dev/null)
+check_result ${?} "ssh probe compiled successfully"
+
 # output results
 echo PASSED: ${PASSED} FAILED: ${FAILED}
 


### PR DESCRIPTION
Adds a working version of the SSH Probe, which is currently broken in the linuxserver smokeping image.

Normally the probe requires SSH is setup on localhost, so it can probe and test the output during init. To avoid having to add sshd to the image, I've added a `SSH_PROBE_INIT_TARGET` env var to set the target used during init.  

`SSH_PROBE_INIT_TARGET` is only required when an SSH probe has been added to the config.

Resolves https://github.com/jwigley/docker-smokeping-speedtest/issues/23