### PR TITLE
feat: make ookla default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The default speedtest configuration will poll downloads/uploads every hour to yo
 Results are displayed under the 'Speed Tests' menu in Smokeping.
 This can be modified by via the Probes and Targets config files as per the instructions at https://github.com/mad-ady/smokeping-speedtest.
 
-The default configuration runs speedtests with the [Sivel](https://github.com/mad-ady/smokeping-speedtest/tree/master#smokepingprobesspeedtest-sivel) probe. If you'd like to use the offical Ookla speedtest instead, uncomment the Ookla section in your Targets config. The Ookla speedtest cli requires you to accept a license on first use. Alternatively you can add the `--accept-license` flag to the `extraargs` parameter in your Probes config.
+The default configuration runs speed tests with the official Ookla speedtest cli tool. The tool requires you to accept a license on first use. Alternatively you can add the `--accept-license` flag to the `extraargs` parameter in your Probes config.
+
+Smokeping-speedtest can also be configured to use [Sivel's speedtest-cli](https://github.com/sivel/speedtest-cli) tool. See the example config in your Targets config file. For best performance and reliable test results, it is recommended to use the official Ookla cli tool for testing internet speeds greater than 100Mbps.
 
 ## ssh probe
 

--- a/conf/Probes
+++ b/conf/Probes
@@ -1,4 +1,5 @@
 
+# Sivel
 + speedtest
 binary = /usr/local/bin/speedtest-cli
 timeout = 300
@@ -14,6 +15,7 @@ measurement = download
 ++ speedtest-upload
 measurement = upload
 
+# Ookla official
 + speedtestcli
 binary = /usr/local/bin/speedtest
 timeout = 300

--- a/conf/Targets
+++ b/conf/Targets
@@ -3,34 +3,36 @@
 menu = Speed Tests
 title = Speed Tests
 
-++ Download
+++ Download-ookla
 menu = Download
 title = Download
-probe = speedtest-download
+probe = speedtestcli-download
 measurement = download
 host = dummy.com
 #server = 1737
 
-++ Upload
+++ Upload-ookla
 menu = Upload
 title = Upload
-probe = speedtest-upload
+probe = speedtestcli-upload
 measurement = upload
 host = dummy.com
 #server = 1737
 
-# ++ Download-ookla
+# ++ Download-sivel
 # menu = Download
 # title = Download
-# probe = speedtestcli-download
+# probe = speedtest-download
 # measurement = download
 # host = dummy.com
 # #server = 1737
 
-# ++ Upload-ookla
+# ++ Upload-sivel
 # menu = Upload
 # title = Upload
-# probe = speedtestcli-upload
+# probe = speedtest-upload
 # measurement = upload
 # host = dummy.com
 # #server = 1737
+
+


### PR DESCRIPTION
Switching the default configured speedtest to use the Ookla cli. 
It produces much more reliable results at internet speeds above 100Mbps.
