### PR TITLE
fix: run tests on copy of build image to avoid issues with COPY /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN apk add python3 --no-cache \
     && cat /speedtest-conf/Targets >> /defaults/smoke-conf/Targets
 
 # Build image with tests
-FROM alpine:latest AS test
-COPY --from=release / /
+FROM release as test
 COPY test/ /test
 WORKDIR /test
 ENTRYPOINT ["/bin/sh", "-c"]


### PR DESCRIPTION
Workaround for test setup suddenly failing with the following when copying over release /. 

```
 Dockerfile:24
--------------------
  22 |     # Build image with tests
  23 |     FROM alpine:latest AS test
  24 | >>> COPY --from=release / /
  25 |     COPY test/ /test
  26 |     WORKDIR /test
--------------------
ERROR: failed to solve: cannot copy to non-directory: /var/lib/buildkit/runc-overlayfs/cachemounts/buildkit3879738234/var/lock
```